### PR TITLE
wifi: Not reset country code for Dual SIM if any slot is active

### DIFF
--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -94,6 +94,7 @@ import android.os.UserHandle;
 import android.os.UserManager;
 import android.os.WorkSource;
 import android.provider.Settings;
+import android.telephony.TelephonyManager;
 import android.util.ArrayMap;
 import android.util.ArraySet;
 import android.util.Log;
@@ -470,6 +471,39 @@ public class WifiServiceImpl extends IWifiManager.Stub {
         mClientHandler.setWifiLog(log);
     }
 
+    // Return true if it is DUAL SIM and either SIM is active.
+    private boolean checkDualSimActive() {
+        TelephonyManager tm = (TelephonyManager)
+                mContext.getSystemService(Context.TELEPHONY_SERVICE);
+
+        if (tm == null) {
+            Log.i(TAG, "checkDualSimActive() is false, tm == null");
+            return false;
+        }
+
+        int phoneCount = tm.getPhoneCount();
+        if (phoneCount < 2) {
+            Log.i(TAG, "checkDualSimActive() is false, phoneCount="
+                    + phoneCount + " slot0State=" + tm.getSimState(0));
+            return false;
+        }
+
+        int slot0State = tm.getSimState(0);
+        int slot1State = tm.getSimState(1);
+        if (slot0State != TelephonyManager.SIM_STATE_READY &&
+                slot1State != TelephonyManager.SIM_STATE_READY) {
+            Log.i(TAG, "checkDualSimActive() is false, slot0State="
+                     + slot0State + " slot1State=" + slot1State);
+            return false;
+        }
+
+        Log.i(TAG, "checkDualSimActive() is true, phoneCount="
+                + phoneCount
+                + " slot0State=" + slot0State + " slot1State=" + slot1State);
+
+        return true;
+    }
+
     /**
      * Check if we are ready to start wifi.
      *
@@ -513,6 +547,10 @@ public class WifiServiceImpl extends IWifiManager.Stub {
                     public void onReceive(Context context, Intent intent) {
                         String state = intent.getStringExtra(IccCardConstants.INTENT_KEY_ICC_STATE);
                         if (IccCardConstants.INTENT_VALUE_ICC_ABSENT.equals(state)) {
+                            if (checkDualSimActive()) {
+                                Log.d(TAG, "Not resetting networks as other SIM may active");
+                                return;
+                            }
                             Log.d(TAG, "resetting networks because SIM was removed");
                             mWifiStateMachine.resetSimAuthNetworks(false);
                             Log.d(TAG, "resetting country code because SIM is removed");


### PR DESCRIPTION
WifiService accepts country code from mccTable, and if one slot
is absent, telephony broadcasts the SIM STATE CHANGED event with
absent state, and based which WifiSerive resets the country code.

This works for single SIM. But for Dual SIM, if one slot is active
and another is absent, telephony broadcasts two SIM STATE CHANGED
events. As the latter one is with absent state, WifiService resets
the country code.

In Dual SIM case, Add check that if any slot is active, WifiService
shall not reset country code.

Change-Id: Icf41d8f4c93616d64796874c55caa39b590d7718
CRs-fixed: 2181365