### PR TITLE
resurrect mWifiLinkLayerStatsSupported counter

### DIFF
--- a/service/java/com/android/server/wifi/WifiStateMachine.java
+++ b/service/java/com/android/server/wifi/WifiStateMachine.java
@@ -313,6 +313,8 @@ public class WifiStateMachine extends StateMachine {
     private final NetworkCapabilities mDfltNetworkCapabilities;
     private SupplicantStateTracker mSupplicantStateTracker;
 
+    private int mWifiLinkLayerStatsSupported = 4; // Temporary disable
+
     // Indicates that framework is attempting to roam, set true on CMD_START_ROAM, set false when
     // wifi connects or fails to connect
     private boolean mIsAutoRoaming = false;
@@ -1249,18 +1251,23 @@ public class WifiStateMachine extends StateMachine {
             loge("getWifiLinkLayerStats called without an interface");
             return null;
         }
+        WifiLinkLayerStats stats = null;
         lastLinkLayerStatsUpdate = mClock.getWallClockMillis();
-        WifiLinkLayerStats stats = mWifiNative.getWifiLinkLayerStats(mInterfaceName);
-        if (stats != null) {
-            mOnTime = stats.on_time;
-            mTxTime = stats.tx_time;
-            mRxTime = stats.rx_time;
-            mRunningBeaconCount = stats.beacon_rx;
-            mWifiInfo.updatePacketRates(stats, lastLinkLayerStatsUpdate);
-        } else {
-            long mTxPkts = mFacade.getTxPackets(mInterfaceName);
-            long mRxPkts = mFacade.getRxPackets(mInterfaceName);
-            mWifiInfo.updatePacketRates(mTxPkts, mRxPkts, lastLinkLayerStatsUpdate);
+        if (mWifiLinkLayerStatsSupported > 0) {
+            stats = mWifiNative.getWifiLinkLayerStats(mInterfaceName);
+            if (stats == null) {
+                mWifiLinkLayerStatsSupported -= 1;
+            } else {
+                mOnTime = stats.on_time;
+                mTxTime = stats.tx_time;
+                mRxTime = stats.rx_time;
+                mRunningBeaconCount = stats.beacon_rx;
+                mWifiInfo.updatePacketRates(stats, lastLinkLayerStatsUpdate);
+            }
+        } else { // LinkLayerStats are broken or unsupported
+                long mTxPkts = mFacade.getTxPackets(mInterfaceName);
+                long mRxPkts = mFacade.getRxPackets(mInterfaceName);
+                mWifiInfo.updatePacketRates(mTxPkts, mRxPkts, lastLinkLayerStatsUpdate);
         }
         return stats;
     }


### PR DESCRIPTION
On devices with broken/not implemented LinkLayerStats
the counter mWifiLinkLayerStatsSupported prevents the following error
messages from appearing every 3 seconds.

03-08 10:43:02.616   389   389 E WifiHAL : wifi_get_link_stats: requestResponse Error:-3
03-08 10:43:02.617  2030  2206 E WifiVendorHal: getWifiLinkLayerStats(l.937) failed {.code = ERROR_NOT_SUPPORTED, .description = }

This partially reverts commit 1ba5b5858ffc04acbd317dc1f6789f1777d375e6.

Change-Id: I840f9d1304bf0a31e7a6b65db00a37dc3651e4b8