### PR TITLE
Prevent scan searching overhead

### DIFF
--- a/service/java/com/android/server/wifi/scanner/WificondScannerImpl.java
+++ b/service/java/com/android/server/wifi/scanner/WificondScannerImpl.java
@@ -411,6 +411,7 @@ public class WificondScannerImpl extends WifiScannerImpl implements Handler.Call
     }
 
     private boolean startHwPnoScan(WifiNative.PnoSettings pnoSettings) {
+        mWifiNative.removeAllNetworks(mIfaceName);
         return mWifiNative.startPnoScan(mIfaceName, pnoSettings);
     }
 


### PR DESCRIPTION
If user connects to a AP but supplicant fails to
connect it successfully, supplicant will trigger
periodical scan to search the AP. The searching
scan brings redudant power consumption under
screen off.
To prevent the overhead, we remove networks to
supplicant before starting PNO scan.

Test: Connect to a nonexistent AP, screen off and
make sure there is no searching scan triggered by
supplicant.
Bug: 124281812
Change-Id: I4a0e99ea1df4fee0b0e3157ed0b82bc83d379765